### PR TITLE
Remove explicit setting of modMail::MAIL_SENDER

### DIFF
--- a/core/components/eletters/model/eletters/eletters.class.php
+++ b/core/components/eletters/model/eletters/eletters.class.php
@@ -188,7 +188,6 @@ class Eletters {
         $this->modx->mail->set(modMail::MAIL_BODY, $this->modx->getChunk($options['emailTpl'], $emailProperties ));
         $this->modx->mail->set(modMail::MAIL_FROM, $options['emailFrom'] );
         $this->modx->mail->set(modMail::MAIL_FROM_NAME, $options['emailFromName'] );
-        $this->modx->mail->set(modMail::MAIL_SENDER, $options['emailFromName'] );
         $this->modx->mail->set(modMail::MAIL_SUBJECT, $options['emailSubject']);
         $this->modx->mail->address('to', $subscriber->get('email') );
         $this->modx->mail->address('reply-to', $options['emailReplyTo'] );


### PR DESCRIPTION
The removed line was causing me some trouble, since it was using the value of `$options['emailFromName']`, which, if set to an actual name like "John Smith", will result in the mail being rejected by some providers (something I've [learned just now](https://www.tectite.com/fmdoc/from_vs_sender.php)).

Of course, we could also change it to `$options['emailFrom']` but the email sender is apparently inferred in [modphpmailer](https://github.com/modxcms/revolution/blob/2.x/core/model/modx/mail/modphpmailer.class.php#L61), anyway.
